### PR TITLE
Feature/talkbackのマージ/gitpod対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # 事前説明
 これはXeliによってForkされたLineChatBotです。
 
-テスト
-
-
 # 前提
 - [Heroku](https://jp.heroku.com/) のアカウントを取得済みであること。
 - Herokuの[CLIツール](https://devcenter.heroku.com/articles/getting-started-with-ruby#set-up)がインストール済みであること。

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # 事前説明
 これはXeliによってForkされたLineChatBotです。
 
+テスト
+
+
 # 前提
 - [Heroku](https://jp.heroku.com/) のアカウントを取得済みであること。
 - Herokuの[CLIツール](https://devcenter.heroku.com/articles/getting-started-with-ruby#set-up)がインストール済みであること。

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# 事前説明
+これはXeliによってForkされたLineChatBotです。
+
 # 前提
 - [Heroku](https://jp.heroku.com/) のアカウントを取得済みであること。
 - Herokuの[CLIツール](https://devcenter.heroku.com/articles/getting-started-with-ruby#set-up)がインストール済みであること。

--- a/config/database.yml
+++ b/config/database.yml
@@ -24,6 +24,7 @@ default: &default
 development:
   <<: *default
   database: ruby-getting-started_development
+  host: /tmp
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,4 +60,5 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
   config.hosts << /[a-z0-9]+\.ngrok\.io/
+  config.hosts << "3000-azure-whitefish-uags9vv2.ws-us03.gitpod.io"
 end


### PR DESCRIPTION
## 実装の背景・目的

🦜返しのLinebotの動作・テストのためにdevelopのconfigを変更

## やったこと

- ReadMeを少し記入
- postgresqlのソケットへのリンクをgitpod上で動作するよう追記
- developのhostにgitpodのdocker imageを追記

## 補足

- これから開発やるぞ〜の準備
- もしgitpodの仮想環境が初期化されるタイプだったら再度ここら辺の設定を注視してなんとかします

