### PR TITLE
Feature/jsonbox test

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -88,7 +88,7 @@ class WebhookController < ApplicationController
   def jsonbox_load_message
     uri = URI.parse(JSONBOX_URL)
     response = Net::HTTP.get_response(uri)
-    message_list = JSON.parse((response.body))
+    message_list = JSON.parse(response.body)
     logger.debug(" [JSONBOX]:Loaded Data #{message_list} , Location:#{JSONBOX_URL}")
     message_list
   end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -97,9 +97,13 @@ class WebhookController < ApplicationController
   ENC_PASSWORD = ENV.fetch("ENC_PASSWORD")
   ENC_SALT = ENV.fetch("ENC_SALT")
 
+  def cipher
+    @cipher ||= OpenSSL::Cipher::AES.new(256, :CBC)
+  end
+
   def encrypt(data)
     # 暗号機を作る
-    enc = OpenSSL::Cipher::AES.new(256, :CBC)
+    enc = cipher
     enc.encrypt
     
     # ENC_PASSWORD,ENC_SALTをもとに鍵・IVを作成・設定
@@ -117,7 +121,7 @@ class WebhookController < ApplicationController
   def decrypt(data)
     encrypted_data = Base64.decode64(data)
     # 復号器を生成
-    dec = OpenSSL::Cipher::AES.new(256, :CBC)
+    dec = cipher
     dec.decrypt
 
     # ENC_PASSWORD,ENC_SALTをもとに鍵・IVを作成・設定
@@ -130,5 +134,4 @@ class WebhookController < ApplicationController
 
     decrypted_data
   end
-
 end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -1,11 +1,16 @@
 require 'line/bot'
 require 'net/http'
 require 'uri'
+require 'json'
+require 'openssl'
+require 'base64'
 
 class WebhookController < ApplicationController
   protect_from_forgery except: [:callback] # CSRF対策無効化
   # 環境変数
   JSONBOX_URL = ENV["JSONBOX_URL"]
+  ENC_PASSWORD = ENV["ENC_PASSWORD"]
+  ENC_SALT = ENV["ENC_SALT"]
 
   def client
     @client ||= Line::Bot::Client.new { |config|
@@ -35,25 +40,28 @@ class WebhookController < ApplicationController
           }
           client.reply_message(event['replyToken'], message)
 
-          # JsonBoxのテスト(FIXME)
+          # JsonBoxにテキストを保存する
           user_id = event['source']['userId']
           message = event.message['text']
           jsonbox_save_message(user_id,message);
-          logger.debug "saved message of #{user_id}: [#{message}], Location:#{JSONBOX_URL}"
 
-        when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
-          response = client.get_message_content(event.message['id'])
-          tf = Tempfile.open("content")
-          tf.write(response.body)
+        # when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
+        #   response = client.get_message_content(event.message['id'])
+        #   tf = Tempfile.open("content")
+        #   tf.write(response.body)
         
         when Line::Bot::Event::MessageType::Sticker
+          # JsonBoxから取得し、返すテスト
+          # JsonBoxからメッセージ一覧を取得し、最初のメッセージを取り出す
+          message_list = jsonbox_load_message()
+          decrypted_message = decrypt(message_list.first["message"]).force_encoding(Encoding::UTF_8)
           message = {
             type: 'text',
-            text: 'HelloWorld!'
+            text: decrypted_message
           }
           test_user_id = User.get_cache.first # テストとして一番最初のユーザにpushする
-          logger.debug "Pushed message to #{test_user_id}"
           client.push_message(test_user_id, message)
+          logger.debug "Pushed message to #{test_user_id}"
         end
       
       when Line::Bot::Event::Follow
@@ -76,9 +84,53 @@ class WebhookController < ApplicationController
     uri = URI.parse(JSONBOX_URL)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
-    params = { user_id: user_id, message: message, like: 0 }
+    params = { user_id: encrypt(user_id), message: encrypt(message), like: 0 }
     headers = { "Content-Type" => "application/json" }
     http.post(uri.path, params.to_json, headers)
-    logger.info(" Posted #{params}")
+    logger.info(" [JSONBOX]:Posted Data #{params} , Location:#{JSONBOX_URL}")
   end
+
+  def jsonbox_load_message()
+    uri = URI.parse(JSONBOX_URL)
+    response = Net::HTTP.get_response(uri)
+    message_list = JSON.parse((response.body))
+    p "READMESSAGE:#{message_list}"
+    logger.debug(" [JSONBOX]:Loaded Data #{message_list} , Location:#{JSONBOX_URL}")
+    message_list
+  end
+
+  def encrypt(data)
+    # 暗号機を作る
+    enc = OpenSSL::Cipher::AES.new(256, :CBC)
+    enc.encrypt
+    
+    # ENC_PASSWORD,ENC_SALTをもとに鍵・IVを作成・設定
+    key_iv = OpenSSL::PKCS5.pbkdf2_hmac(ENC_PASSWORD, ENC_SALT, 2000, enc.key_len + enc.iv_len, "sha256")
+    enc.key = key_iv[0, enc.key_len]
+    enc.iv = key_iv[enc.key_len, enc.iv_len]
+
+    # 暗号化 & Base64Encode
+    encrypted_data = enc.update(data) + enc.final
+    encrypted_data = Base64.encode64(encrypted_data).chomp
+
+    encrypted_data
+  end
+
+  def decrypt(data)
+    encrypted_data = Base64.decode64(data)
+    # 復号器を生成
+    dec = OpenSSL::Cipher::AES.new(256, :CBC)
+    dec.decrypt
+
+    # ENC_PASSWORD,ENC_SALTをもとに鍵・IVを作成・設定
+    key_iv = OpenSSL::PKCS5.pbkdf2_hmac(ENC_PASSWORD, ENC_SALT, 2000, dec.key_len + dec.iv_len, "sha256")
+    dec.key = key_iv[0, dec.key_len]
+    dec.iv = key_iv[dec.key_len, dec.iv_len]
+
+    # 暗号を復号
+    decrypted_data = dec.update(encrypted_data) + dec.final
+
+    decrypted_data
+  end
+
 end


### PR DESCRIPTION
## 実装の背景・目的

JsonBoxとの連携機能と、暗号化機能を作って・そのメッセージを送信するテストを記述

## やったこと

- Jsonbox_save_message, Jsonbox_load_messageを実装
- encrypt,decryptのメソッドを実装
- Stickerを送ったときにJsonboxの最新のメッセージを送るテスト機能

## キャプチャ

![hmKAsK0](https://user-images.githubusercontent.com/42743988/115827972-02697b80-a448-11eb-886f-51cd58785511.jpg)

## 補足

- 反省：機能が多めのPR
