### PR TITLE
Feature/push random message

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -43,19 +43,12 @@ class WebhookController < ApplicationController
           jsonbox_save_message(user_id,message);
         
         when Line::Bot::Event::MessageType::Sticker
-          # JsonBoxからランダムなメッセージをランダムな登録ユーザにpushする
+          # JsonBoxからランダムなメッセージをスタンプを送ったユーザにpushする
           message = {
             type: 'text',
             text: random_message_select
           }
-          user_ids = User.get_cache
-          begin
-            random_user_id = user_ids[Random.rand(user_ids.size)]
-            client.push_message(random_user_id, message)
-            logger.debug "Pushed message [#{message}] to #{random_user_id}"
-          rescue => exception
-            logger.error "[Error!] #{exception} happen; maybe 0 user cache?"
-          end
+          client.reply_message(event['replyToken'], message)
         end
       
       when Line::Bot::Event::Follow
@@ -77,8 +70,7 @@ class WebhookController < ApplicationController
   # Message送信関連
   def random_message_select
     message_list = jsonbox_load_message
-    random_num = Random.rand(message_list.size)
-    random_message = decrypt(base64_decode(message_list[random_num]["message"]))
+    random_message = decrypt(base64_decode(message_list.sample["message"]))
     random_message
   end
 

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -45,10 +45,10 @@ class WebhookController < ApplicationController
           # JsonBoxから取得し、返すテスト
           # JsonBoxからメッセージ一覧を取得し、最初のメッセージを取り出す
           message_list = jsonbox_load_message
-          decrypted_message = decrypt(Base64.decode64(message_list.first["message"]).chomp).force_encoding(Encoding::UTF_8)
+          random_message = random_message_select(message_list)
           message = {
             type: 'text',
-            text: decrypted_message
+            text: random_message
           }
           test_user_id = User.get_cache.first # テストとして一番最初のユーザにpushする
           client.push_message(test_user_id, message)
@@ -70,6 +70,17 @@ class WebhookController < ApplicationController
   end
 
   private
+
+  # Message送信関連
+  def random_message_select(message_list)
+    random_num = Random.rand(message_list.size)
+    random_message = decrypt(base64_decode(message_list[random_num]["message"]))
+    random_message
+  end
+
+  def base64_decode(data)
+    Base64.decode64(data).chomp
+  end
 
   # JsonBox
   DEFAULT_LIKE_NUM = 0
@@ -127,6 +138,6 @@ class WebhookController < ApplicationController
     # 暗号を復号
     decrypted_data = dec.update(encrypted_data) + dec.final
 
-    decrypted_data
+    decrypted_data.force_encoding(Encoding::UTF_8)
   end
 end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -78,6 +78,10 @@ class WebhookController < ApplicationController
     random_message
   end
 
+  def base64_encode(data)
+    Base64.encode64(data).chomp
+  end
+
   def base64_decode(data)
     Base64.decode64(data).chomp
   end
@@ -89,7 +93,7 @@ class WebhookController < ApplicationController
     uri = URI.parse(ENV.fetch("JSONBOX_URL"))
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
-    params = { user_id: Base64.encode64(encrypt(user_id)).chomp, message: Base64.encode64(encrypt(message)).chomp, like: DEFAULT_LIKE_NUM }
+    params = { user_id: base64_encode(encrypt(user_id)), message: base64_encode(encrypt(message)), like: DEFAULT_LIKE_NUM }
     headers = { "Content-Type" => "application/json" }
     http.post(uri.path, params.to_json, headers)
     logger.info(" [JSONBOX]:Posted Data #{params}")

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -44,11 +44,9 @@ class WebhookController < ApplicationController
         
         when Line::Bot::Event::MessageType::Sticker
           # JsonBoxからランダムなメッセージをランダムな登録ユーザにpushする
-          message_list = jsonbox_load_message
-          random_message = random_message_select(message_list)
           message = {
             type: 'text',
-            text: random_message
+            text: random_message_select
           }
           user_ids = User.get_cache
           begin
@@ -77,7 +75,8 @@ class WebhookController < ApplicationController
   private
 
   # Message送信関連
-  def random_message_select(message_list)
+  def random_message_select
+    message_list = jsonbox_load_message
     random_num = Random.rand(message_list.size)
     random_message = decrypt(base64_decode(message_list[random_num]["message"]))
     random_message

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -70,8 +70,7 @@ class WebhookController < ApplicationController
   # Message送信関連
   def random_message_select
     message_list = jsonbox_load_message
-    random_message = decrypt(base64_decode(message_list.sample["message"]))
-    random_message
+    decrypt(base64_decode(message_list.sample["message"]))
   end
 
   def base64_encode(data)

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -67,7 +67,7 @@ class WebhookController < ApplicationController
 
       when Line::Bot::Event::Unfollow
         user_id = event['source']['userId']
-        #User.delete_cache(user_id)
+        User.delete_cache(user_id)
         logger.debug "UserIdList = #{User.get_cache}"
       end
     }


### PR DESCRIPTION
## 実装の背景・目的

メッセージのランダム化・実際にはこの機能がなければ辛いため

## やったこと

- スタンプを送った時ランダムなメッセージを選択する
- 同じタイミングでランダムなユーザにpushする
- Encode,Decode関連の処理が複雑化したので一旦まとめる形でbase64_encode/decodeを作成

## キャプチャ

## 補足
